### PR TITLE
feat: add route method to EmailEndpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ testbench.yaml
 /coverage
 composer.lock
 openapi.json
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ $lettermint->email
     ->text('Hello!')
     ->headers(['X-Custom-Header' => 'Value'])
     ->attach('document.pdf', base64_encode($fileContent))
+    ->route('my-route-id')
     ->send();
 ```
 

--- a/src/Endpoints/EmailEndpoint.php
+++ b/src/Endpoints/EmailEndpoint.php
@@ -141,6 +141,18 @@ class EmailEndpoint extends Endpoint
     }
 
     /**
+     * Set the route id for the email.
+     *
+     * @param string $route The route id to use for sending.
+     * @return self
+     */
+    public function route(string $route): self
+    {
+        $this->payload['route'] = $route;
+        return $this;
+    }
+
+    /**
      * Send the composed email using the current payload.
      *
      * @return array The API response as an associative array.


### PR DESCRIPTION
Introduced the `route` method to set a route ID for emails, enhancing customization for email delivery. Updated the README to include usage of the `route` method