### PR TITLE
feat: add idempotency support to EmailEndpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ You can install the package via composer:
 composer require lettermint/lettermint-php
 ```
 
-
 ## Usage
 
 Initialize the Lettermint client with your API token:
+
 ```php
 $lettermint = new Lettermint\Lettermint('your-api-token');
 ```
 
-
 ### Sending Emails
 
 The SDK provides a fluent interface for composing and sending emails:
+
 ```php
 $response = $lettermint->email
                        ->from('sender@example.com')
@@ -57,9 +57,28 @@ $lettermint->email
     ->headers(['X-Custom-Header' => 'Value'])
     ->attach('document.pdf', base64_encode($fileContent))
     ->route('my-route-id')
+    ->idempotencyKey('unique-request-id-123')
     ->send();
 ```
 
+### Idempotency
+
+To ensure that duplicate requests are not processed, you can use an idempotency key:
+
+```php
+$response = $lettermint->email
+                       ->from('sender@example.com')
+                       ->to('recipient@example.com')
+                       ->subject('Hello from Lettermint!')
+                       ->text('Hello! This is a test email.')
+                       ->idempotencyKey('unique-request-id-123')
+                       ->send();
+```
+
+The idempotency key should be a unique string that you generate for each unique email you want to send. If you make the
+same request with the same idempotency key, the API will return the same response without sending a duplicate email.
+
+For more information, refer to the [documentation](https://docs.lettermint.co/platform/emails/idempotency).
 
 ## Testing
 

--- a/src/Client/HttpClient.php
+++ b/src/Client/HttpClient.php
@@ -8,7 +8,9 @@ use GuzzleHttp\Exception\GuzzleException;
 class HttpClient
 {
     private string $apiToken;
+
     private string $baseUrl;
+
     private Client $client;
 
     public function __construct(string $apiToken, string $baseUrl)
@@ -17,7 +19,7 @@ class HttpClient
         $this->baseUrl = rtrim($baseUrl, '/');
         $this->client = new Client([
             'base_uri' => $this->baseUrl,
-            'timeout'  => 15,
+            'timeout' => 15,
             'headers' => [
                 'Content-Type' => 'application/json',
                 'x-lettermint-token' => $this->apiToken,
@@ -28,26 +30,31 @@ class HttpClient
     /**
      * Fluent-style usage with dedicated endpoints (builder pattern)
      *
-     * @param string $path
-     * @param array $data
+     * @param  array  $headers  Additional headers for this request
      * @return array Resulting API response
+     *
      * @throws \Exception On HTTP or decode failure
      */
-    public function post(string $path, array $data): array
+    public function post(string $path, array $data, array $headers = []): array
     {
         try {
-            $response = $this->client->post($path, [
-                'json' => $data
-            ]);
+            $requestOptions = ['json' => $data];
+
+            if (! empty($headers)) {
+                $requestOptions['headers'] = $headers;
+            }
+
+            $response = $this->client->post($path, $requestOptions);
             $body = $response->getBody()->getContents();
             $result = json_decode($body, true);
 
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new \Exception('Could not decode API response');
             }
+
             return $result;
         } catch (GuzzleException $e) {
-            throw new \Exception('API request failed: ' . $e->getMessage(), 0, $e);
+            throw new \Exception('API request failed: '.$e->getMessage(), 0, $e);
         }
     }
 }


### PR DESCRIPTION
Introduced support for idempotency keys in the EmailEndpoint to prevent duplicate email processing by the API. Updated tests to verify behavior with and without idempotency keys. Enhanced the README with examples and a detailed explanation of idempotency usage.