### PR TITLE
Add metadata support for emails

### DIFF
--- a/src/Endpoints/EmailEndpoint.php
+++ b/src/Endpoints/EmailEndpoint.php
@@ -15,7 +15,7 @@ class EmailEndpoint extends Endpoint
     private ?string $idempotencyKey = null;
 
     /**
-     * Set the custom headeres.
+     * Set the custom headers.
      *
      * @example ["Key" => "Value"]
      *
@@ -165,6 +165,20 @@ class EmailEndpoint extends Endpoint
     public function idempotencyKey(string $key): self
     {
         $this->idempotencyKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set custom metadata.
+     *
+     * @example ["key" => "value"]
+     *
+     * @param  array<string, string>  $metadata  The metadata object.
+     */
+    public function metadata(array $metadata): self
+    {
+        $this->payload['metadata'] = $metadata;
 
         return $this;
     }

--- a/tests/Endpoints/EmailEndpointTest.php
+++ b/tests/Endpoints/EmailEndpointTest.php
@@ -233,3 +233,23 @@ test('it sends without idempotency key when not set', function () {
         ->subject('Test Subject')
         ->send();
 });
+
+test('it handles metadata', function () {
+    $this->httpClient
+        ->shouldReceive('post')
+        ->once()
+        ->with('/v1/send', [
+            'from' => 'sender@example.com',
+            'to' => ['recipient@example.com'],
+            'subject' => 'Test Subject',
+            'metadata' => ['foo' => 'bar'],
+        ], [])
+        ->andReturn(['message_id' => '123', 'status' => 'pending']);
+
+    $this->endpoint
+        ->from('sender@example.com')
+        ->to('recipient@example.com')
+        ->subject('Test Subject')
+        ->metadata(['foo' => 'bar'])
+        ->send();
+});


### PR DESCRIPTION
Added support for custom metadata in the `EmailEndpoint` to enhance email customization. Updated existing test cases to ensure metadata functionality is working as intended. Fixed minor typo in PHPDoc for the headers method.