### PR TITLE
Add tag support to EmailEndpoint

### DIFF
--- a/src/Endpoints/EmailEndpoint.php
+++ b/src/Endpoints/EmailEndpoint.php
@@ -184,6 +184,18 @@ class EmailEndpoint extends Endpoint
     }
 
     /**
+     * Set the tag of the email.
+     *
+     * @param  string|null  $tag  The tag formatted as slug
+     */
+    public function tag(?string $tag): self
+    {
+        $this->payload['tag'] = $tag;
+
+        return $this;
+    }
+
+    /**
      * Send the composed email using the current payload.
      *
      * @return array The API response as an associative array.

--- a/tests/Endpoints/EmailEndpointTest.php
+++ b/tests/Endpoints/EmailEndpointTest.php
@@ -253,3 +253,23 @@ test('it handles metadata', function () {
         ->metadata(['foo' => 'bar'])
         ->send();
 });
+
+test('it handles tags', function () {
+    $this->httpClient
+        ->shouldReceive('post')
+        ->once()
+        ->with('/v1/send', [
+            'from' => 'sender@example.com',
+            'to' => ['recipient@example.com'],
+            'subject' => 'Test Subject',
+            'tag' => 'campaign',
+        ], [])
+        ->andReturn(['message_id' => '123', 'status' => 'pending']);
+
+    $this->endpoint
+        ->from('sender@example.com')
+        ->to('recipient@example.com')
+        ->subject('Test Subject')
+        ->tag('campaign')
+        ->send();
+});


### PR DESCRIPTION
Added functionality to set tags for emails using a new `tag` method, improving customization options for email handling. This includes updates to the payload structure and a new test to confirm correct tag processing and behavior.