### PR TITLE
Make HTTP client timeout configurable

### DIFF
--- a/src/Client/ApiClient.php
+++ b/src/Client/ApiClient.php
@@ -39,11 +39,12 @@ class ApiClient
         'webhooks' => WebhooksEndpoint::class,
     ];
 
-    public function __construct(string $apiToken, ?string $baseUrl = null)
+    public function __construct(string $apiToken, ?string $baseUrl = null, int $timeout = 15)
     {
         $this->httpClient = new HttpClient(
             new TeamBearerTokenAuth($apiToken),
-            $baseUrl ?? 'https://api.lettermint.co/v1'
+            $baseUrl ?? 'https://api.lettermint.co/v1',
+            $timeout
         );
     }
 

--- a/src/Client/HttpClient.php
+++ b/src/Client/HttpClient.php
@@ -21,13 +21,13 @@ class HttpClient
 
     private Client $client;
 
-    public function __construct(AuthStrategy|string $auth, string $baseUrl)
+    public function __construct(AuthStrategy|string $auth, string $baseUrl, int $timeout = 15)
     {
         $this->auth = is_string($auth) ? new SendingApiTokenAuth($auth) : $auth;
         $this->baseUrl = rtrim($baseUrl, '/');
         $this->client = new Client([
             'base_uri' => $this->baseUrl,
-            'timeout' => 15,
+            'timeout' => $timeout,
             'headers' => [
                 'Content-Type' => 'application/json',
                 ...$this->auth->headers(),

--- a/src/Lettermint.php
+++ b/src/Lettermint.php
@@ -24,23 +24,24 @@ class Lettermint
         'email' => EmailEndpoint::class,
     ];
 
-    public function __construct(string $apiToken, ?string $baseUrl = null)
+    public function __construct(string $apiToken, ?string $baseUrl = null, int $timeout = 15)
     {
         $this->apiToken = $apiToken;
         $this->baseUrl = $baseUrl ?? 'https://api.lettermint.co/v1';
-        $this->httpClient = new HttpClient($this->apiToken, $this->baseUrl);
+        $this->httpClient = new HttpClient($this->apiToken, $this->baseUrl, $timeout);
     }
 
-    public static function api(string $apiToken, ?string $baseUrl = null): ApiClient
+    public static function api(string $apiToken, ?string $baseUrl = null, int $timeout = 15): ApiClient
     {
-        return new ApiClient($apiToken, $baseUrl);
+        return new ApiClient($apiToken, $baseUrl, $timeout);
     }
 
-    public static function email(string $apiToken, ?string $baseUrl = null): EmailEndpoint
+    public static function email(string $apiToken, ?string $baseUrl = null, int $timeout = 15): EmailEndpoint
     {
         return new EmailEndpoint(new HttpClient(
             new SendingApiTokenAuth($apiToken),
-            $baseUrl ?? 'https://api.lettermint.co/v1'
+            $baseUrl ?? 'https://api.lettermint.co/v1',
+            $timeout
         ));
     }
 

--- a/tests/Client/HttpClientTest.php
+++ b/tests/Client/HttpClientTest.php
@@ -165,3 +165,30 @@ test('it trims trailing slashes from base url', function () {
 
     expect($property->getValue($client))->toBe('http://api.example.com');
 });
+
+test('it defaults to a 15 second timeout', function () {
+    $client = new HttpClient($this->apiToken, $this->baseUrl);
+
+    expect(guzzleTimeout($client))->toBe(15);
+});
+
+test('it uses a custom timeout when provided', function () {
+    $client = new HttpClient($this->apiToken, $this->baseUrl, 60);
+
+    expect(guzzleTimeout($client))->toBe(60);
+});
+
+/**
+ * Read the Guzzle client's configured timeout out of a HttpClient instance.
+ */
+function guzzleTimeout(HttpClient $httpClient): int
+{
+    $clientProperty = (new ReflectionClass($httpClient))->getProperty('client');
+    $clientProperty->setAccessible(true);
+    $guzzle = $clientProperty->getValue($httpClient);
+
+    $configProperty = (new ReflectionClass($guzzle))->getProperty('config');
+    $configProperty->setAccessible(true);
+
+    return $configProperty->getValue($guzzle)['timeout'];
+}


### PR DESCRIPTION
The Guzzle timeout in `HttpClient` is hardcoded to `15` seconds with no way to override it:

```php
$this->client = new Client([
    "base_uri" => $this->baseUrl,
    "timeout" => 15,
    // ...
]);
```

For large `POST /v1/send/batch` requests the API occasionally needs longer than 15s to respond, which surfaces as `cURL error 28: Operation timed out after 15001 milliseconds with 0 bytes received` and aborts the send.

## Change

Thread an optional `int $timeout = 15` parameter through the whole construction path:

- `HttpClient::__construct(..., int $timeout = 15)` — uses it for the Guzzle `timeout` option
- `ApiClient::__construct(..., int $timeout = 15)`
- `Lettermint::__construct(..., int $timeout = 15)`
- `Lettermint::email(..., int $timeout = 15)` / `Lettermint::api(..., int $timeout = 15)`

The default stays `15`, so this is **fully backward-compatible** — existing callers are unaffected.

## Usage

```php
$email = Lettermint::email($token, timeout: 60);
```

## Tests

Added two cases to `HttpClientTest` verifying the default 15s timeout and a custom timeout are applied to the underlying Guzzle client. Full suite (`pest`) and `phpstan` pass.